### PR TITLE
Calculate GC Percentage and output to stdout

### DIFF
--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -24,5 +24,12 @@ echo "Processing FASTQ file: $FASTQ_FILE"
 LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 ## Calculate the number of reads (4 lines per read)
 READ_COUNT=$((LINE_COUNT / 4))
+## Count the number of G and C bases in FASTQ file
+GC_COUNT=$(sed -n '2~4p' $FASTQ_FILE | tr -cd 'GCgc' | wc -c)
+## Count the total number of bases in FASTQ file
+TOTAL_BASE_COUNT=$(sed -n '2~4p' $FASTQ_FILE | tr -cd 'ATCGatcg' | wc -c)
+## Calculate GC percent with awk because bc isn't recognized...
+GC_PERCENT=$(awk "BEGIN {print ($GC_COUNT / $TOTAL_BASE_COUNT) * 100}")
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+echo "GC percent in $FASTQ_FILE: $GC_PERCENT"


### PR DESCRIPTION
## Description 
A feature was requested to calculate GC percentage from raw read files (.fastq). GC percentage calculation has been added and output is printed to stdout.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tested using simulated read file with known GC counts (see data/sample.fastq)

## Checklist:
- [X] My code adheres to the [repository style guide](https://github.com/theiagen/Northeast-SDP4PHB-2025/blob/main/style-guide.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes